### PR TITLE
Fix for empty encodedValue in php 7

### DIFF
--- a/library/Zend/Json.php
+++ b/library/Zend/Json.php
@@ -74,6 +74,14 @@ class Zend_Json
     public static function decode($encodedValue, $objectDecodeType = Zend_Json::TYPE_ARRAY)
     {
         $encodedValue = (string) $encodedValue;
+        // fix for php7 (empty strings result in syntax error for php >= 7.0.0)
+        if (empty($encodedValue)) {
+            if ($objectDecodeType == Zend_Json::TYPE_ARRAY) {
+                return array();
+            } else  {
+                return (object)array();
+            }
+        }
         if (function_exists('json_decode') && self::$useBuiltinEncoderDecoder !== true) {
             $decode = json_decode($encodedValue, $objectDecodeType);
 

--- a/library/Zend/Json.php
+++ b/library/Zend/Json.php
@@ -74,14 +74,11 @@ class Zend_Json
     public static function decode($encodedValue, $objectDecodeType = Zend_Json::TYPE_ARRAY)
     {
         $encodedValue = (string) $encodedValue;
-        // fix for php7 (empty strings result in syntax error for php >= 7.0.0)
+        // fix for php7 (empty strings result in syntax error for php >= 7.0.0 if calling json_last_error)
         if (empty($encodedValue)) {
-            if ($objectDecodeType == Zend_Json::TYPE_ARRAY) {
-                return array();
-            } else  {
-                return (object)array();
-            }
+            return null;
         }
+
         if (function_exists('json_decode') && self::$useBuiltinEncoderDecoder !== true) {
             $decode = json_decode($encodedValue, $objectDecodeType);
 


### PR DESCRIPTION
PHP 7 changes the behaviour of this method. This is a fix for that. Of course the code should be changed to not use empty strings, but zf1 is legacy, so this is for legacy code which relies on this exact behaviour.
We could also check for the empty encodedValue in the error handling code.